### PR TITLE
Small bug when clearing features

### DIFF
--- a/src/bilou/ner_sentence.cpp
+++ b/src/bilou/ner_sentence.cpp
@@ -34,7 +34,7 @@ void ner_sentence::resize(unsigned size) {
 
 void ner_sentence::clear_features() {
   for (unsigned i = 0; i < size; i++)
-    features.clear();
+    features[i].clear();
 }
 
 void ner_sentence::clear_probabilities_local_filled() {

--- a/src/tagger/morphodita_tagger.cpp
+++ b/src/tagger/morphodita_tagger.cpp
@@ -35,7 +35,7 @@ bool morphodita_tagger::create_and_encode(const string& params, FILE* f) {
   if (!in) return eprintf("Cannot open morphodita tagger file '%s'!\n", params.c_str()), false;
 
   if (!load(in)) {
-    eprintf("Cannot load morphodita tagger fromf ile '%s'!\n", params.c_str());
+    eprintf("Cannot load morphodita tagger from file '%s'!\n", params.c_str());
     return false;
   }
 


### PR DESCRIPTION
Fixed a small bug where the whole feature vector was cleared instead of the individual features.
This has caused exceptions in some instances, e.g. in bilou_ner_trainer::compute_previous_stage, when processing the sentence after clearing the vector of features.
